### PR TITLE
Add force_unicode() for generic logging.

### DIFF
--- a/redis_sniffer/log.py
+++ b/redis_sniffer/log.py
@@ -27,23 +27,33 @@ class Log:
         for event in filters:
             self.files[event] = io.open(location + event + append, 'w')
 
+    def force_unicode(self, data):
+        # treat the data as latin1 bytes to support any binary junk in
+        # the redis data
+        return data.decode('iso-8859-1')
+
     def write_event(self, event):
+        event = self.force_unicode(event)
         self.event_log.write(unicode(event))
         self.event_log.flush()
 
     def write_log(self, log):
+        log = self.force_unicode(log)
         self.full_log.write(unicode(log))
         self.full_log.flush()
 
     def write_debug(self, data):
+        data = self.force_unicode(data)
         self.debug_log.write(unicode(data))
         self.debug_log.flush()
 
     def write_command(self, event, command):
+        command = self.force_unicode(command)
         if event in self.files.keys():
             self.files[event].write(unicode(command))
             self.files[event].flush()
 
     def write_extra(self, data):
+        data = self.force_unicode(data)
         self.extra_log.write(unicode(data))
         self.extra_log.flush()


### PR DESCRIPTION
At least on Ubuntu 14.04, I get "UnicodeDecodeError: 'ascii' codec can't
decode byte 0xe2 in position 139: ordinal not in range(128)" without
this.
